### PR TITLE
StatsD duplicator and Graph Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ In a normal setup, here's how to configure graphits/statsd:
     docker run -d\
      --name graphite\
      --restart=always\
+     --privileged\
      -p 8080:80\
      -p 8125:8125/udp\
      -p 8126:8126\

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Once configured, any modern web browser can connect to Vitality GOES and view th
 
 Goesrecv supports logging information about error correction rate, packet drop rates, and so on to a statsd server. This information is invaluable to ground station operators, so it should be made easily accessible. This project accomplishes this by staging the information in a Graphite database, which Vitality GOES can then query and present to the user.
 
-Configuring Graphite is not necessary to use Vitality GOES, but no graphs will be available if you don't set it up. If Vitality GOES is on a different machine from goestools, graphite/statsd can be installed on either machine. To configure graphits/statsd:
+Configuring Graphite is not necessary to use Vitality GOES, but no graphs will be available if you don't set it up. If Vitality GOES is on a different machine from goestools, graphite/statsd can be installed on either machine. In a normal setup, here's how to configure graphits/statsd:
 
 1. Install Docker on the target machine. This varies by distro, but you can find instructions for Ubuntu and its variants [here](https://docs.docker.com/engine/install/ubuntu/) and Raspberry Pi OS [here](https://dev.to/elalemanyo/how-to-install-docker-and-docker-compose-on-raspberry-pi-1mo). Docker Compose is not required.
 2. As root, run the following commands to create a storage area for graphite.
@@ -84,6 +84,8 @@ Configuring Graphite is not necessary to use Vitality GOES, but no graphs will b
 That's it! To verify it's working, go to http://graphiteip:8080/ (example: http://192.168.1.123:8080/) and make sure you see something that looks like this:
 
 ![Example of what Graphite should look like when installed](resources/graphite.png)
+
+**If you're currently using Grafana, you'll need to follow extra steps to keep using it.** [See here for more details](docs/grafana-compatibility.md). Alternatively, you can choose to stop using Grafana, or disable graphs within Vitality GOES.
 
 ### goestools
 To assist you in configuring goestools for Vitality GOES, sample `goesrecv.conf` and `goesproc-goesr.conf` files have been included in the goestools-conf folder of this repository. These files are pretty close to "stock" suggested files. You do not need to use these exact configs. You might want to remove sections you won't be using, and you'll need do do a "Find & Replace" to update the directory to where you want your GOES products stored. In the end, your setup should be configured as follows:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ In a normal setup, here's how to configure graphits/statsd:
      -v /var/lib/graphite/log:/var/log\
      graphiteapp/graphite-statsd
      ```
-That's it! To verify it's working, go to http://graphiteip:8080/ (example: http://192.168.1.123:8080/) and make sure you see something that looks like the screenshot below. If you get an Error 502, wait 2 minutes and check again - graphite can take a minute to start on slower machines like a Raspberry Pi.
+That's it! To verify it's working, go to http://graphiteip:8080/ (example: http://192.168.1.123:8080/) and make sure you see something that looks like the screenshot below.
+
+**If you get an Error 502**, wait 2 minutes and check again - graphite can take a minute to start on slower machines like a Raspberry Pi.
 
 ![Example of what Graphite should look like when installed](resources/graphite.png)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In a normal setup, here's how to configure graphits/statsd:
      -v /var/lib/graphite/log:/var/log\
      graphiteapp/graphite-statsd
      ```
-That's it! To verify it's working, go to http://graphiteip:8080/ (example: http://192.168.1.123:8080/) and make sure you see something that looks like this:
+That's it! To verify it's working, go to http://graphiteip:8080/ (example: http://192.168.1.123:8080/) and make sure you see something that looks like the screenshot below. If you get an Error 502, wait 2 minutes and check again - graphite can take a minute to start on slower machines like a Raspberry Pi.
 
 ![Example of what Graphite should look like when installed](resources/graphite.png)
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Once configured, any modern web browser can connect to Vitality GOES and view th
 
 Goesrecv supports logging information about error correction rate, packet drop rates, and so on to a statsd server. This information is invaluable to ground station operators, so it should be made easily accessible. This project accomplishes this by staging the information in a Graphite database, which Vitality GOES can then query and present to the user.
 
-Configuring Graphite is not necessary to use Vitality GOES, but no graphs will be available if you don't set it up. If Vitality GOES is on a different machine from goestools, graphite/statsd can be installed on either machine. In a normal setup, here's how to configure graphits/statsd:
+Configuring Graphite is not necessary to use Vitality GOES, but no graphs will be available if you don't set it up. If Vitality GOES is on a different machine from goestools, graphite/statsd can be installed on either machine.
 
-1. Install Docker on the target machine. This varies by distro, but you can find instructions for Ubuntu and its variants [here](https://docs.docker.com/engine/install/ubuntu/) and Raspberry Pi OS [here](https://dev.to/elalemanyo/how-to-install-docker-and-docker-compose-on-raspberry-pi-1mo). Docker Compose is not required.
+**If you're currently using Grafana, you'll need to follow extra steps to keep using it.** [See here for more details](docs/grafana-compatibility.md). Alternatively, you can choose to stop using Grafana, or disable graphs within Vitality GOES.
+
+In a normal setup, here's how to configure graphits/statsd:
+
+1. If you're not using it already, install Docker on the target machine. This varies by distro, but you can find instructions for Ubuntu and its variants [here](https://docs.docker.com/engine/install/ubuntu/) and Raspberry Pi OS [here](https://dev.to/elalemanyo/how-to-install-docker-and-docker-compose-on-raspberry-pi-1mo). Docker Compose is not required.
 2. As root, run the following commands to create a storage area for graphite.
     ```
     mkdir -p /var/lib/graphite/config
@@ -84,8 +88,6 @@ Configuring Graphite is not necessary to use Vitality GOES, but no graphs will b
 That's it! To verify it's working, go to http://graphiteip:8080/ (example: http://192.168.1.123:8080/) and make sure you see something that looks like this:
 
 ![Example of what Graphite should look like when installed](resources/graphite.png)
-
-**If you're currently using Grafana, you'll need to follow extra steps to keep using it.** [See here for more details](docs/grafana-compatibility.md). Alternatively, you can choose to stop using Grafana, or disable graphs within Vitality GOES.
 
 ### goestools
 To assist you in configuring goestools for Vitality GOES, sample `goesrecv.conf` and `goesproc-goesr.conf` files have been included in the goestools-conf folder of this repository. These files are pretty close to "stock" suggested files. You do not need to use these exact configs. You might want to remove sections you won't be using, and you'll need do do a "Find & Replace" to update the directory to where you want your GOES products stored. In the end, your setup should be configured as follows:

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -17,7 +17,7 @@ The solution is to use an alternative configuration for graphite/statsd, along w
     systemctl enable statsdduplicator
     systemctl start statsdduplicator
     ```
-6. Follow the normal steps in the readme under [Preparing your system for Vitality GOES > Graphite/statsd](/readme.md#graphitestatsd). The only difference is that you will want to use this command instead for step 4:
+6. Follow the normal steps in the readme under [Preparing your system for Vitality GOES > Graphite/statsd](/README.md#graphitestatsd). The only difference is that you will want to use this command instead for step 4:
    ```
    docker run -d\
     --name graphite\

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -34,7 +34,7 @@ The solution is to use an alternative configuration for graphite/statsd, along w
 
 ## How does it work?
 
-Goesrecv sends statsd statistics to the StatsD Duplicator service on port 8325. StatsD Duplicator then sends the statistics both to graphite/statsd (and therefore, Vitality GOES) on port 8225, as well as Grafana on port 8125.
+Goesrecv sends statsd statistics to the StatsD Duplicator service on port 8325. StatsD Duplicator then sends the statistics both to Grafana on port 8125, as well as graphite/statsd (and therefore, Vitality GOES) on port 8225.
 
 ## Other Tidbits
 

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -1,0 +1,47 @@
+# Running Graphite and Grafana at the same time
+
+Within the community, it's popular to run Grafana to track statsd statistcs from goesrecv. The problem is, Goesrecv only supports sending statsd statistics to one statsd host at a time, and Vitality GOES uses graphite/statsd as its statsd handler. This begs the question: if you want to have statistics in both Vitality GOES and Grafana, how do you do that?
+
+The solution is to use an alternative configuration for graphite/statsd, along with a helper service. No changes are needed to your Grafana setup. For simplicity, these instructions assume you have goesrecv, Grafana, and graphite/statsd all running on the same machine. Here are the steps:
+
+1. Modify the `[monitor]` section of your goesrecv.conf file to look like this (don't forget to restart goesrecv afterwards):
+
+   ```
+   [monitor]
+   statsd_address = "udp4://127.0.0.1:8325"
+   ```
+3. Copy [extra/statsdduplicator.service](/extra/statsdduplicator.service) from this repo to /usr/lib/systemd/system/statsdsplitter.service on your ground station machine
+4. Run the following commands **as root**:
+    ```
+    systemctl daemon-reload
+    systemctl enable statsdduplicator
+    systemctl start statsdduplicator
+    ```
+6. Follow the normal steps in the readme under [Preparing your system for Vitality GOES > Graphite/statsd](/readme.md#graphitestatsd). The only difference is that you will want to use this command instead for step 4:
+   ```
+   docker run -d\
+    --name graphite\
+    --restart=always\
+    -p 8080:80\
+    -p 8225:8125/udp\
+    -p 8126:8126\
+    -v /var/lib/graphite/config:/opt/graphite/conf\
+    -v /var/lib/graphite/data:/opt/graphite/storage\
+    -v /var/lib/graphite/statsd_config:/opt/statsd/config\
+    -v /var/lib/graphite/log:/var/log\
+    graphiteapp/graphite-statsd
+   ```
+
+## How does it work?
+
+Goesrecv sends statsd statistics to the StatsD Duplicator service on port 8325. StatsD Duplicator then sends the statistics both to graphite/statsd (and therefore, Vitality GOES) on port 8225, as well as Grafana on port 8125.
+
+## Other Tidbits
+
+#### I already set up graphite with the instructions in the main readme and now everything's broken. How do I fix it?
+As root, run `docker stop graphite && docker rm graphite`. Then `docker run...` command above to make it use the custom port.
+
+#### I'm an advanced user, and I have graphite and Grafana running on different machines. How do I make this work for me?
+After creating the file at /usr/lib/systemd/system/statsdsplitter.service on your ground station, edit it (ex. `sudo nano /usr/lib/systemd/system/statsdsplitter.service`). Edit the IPs and ports after each `udp4-datagram` to match your Grafana and graphite/statsd instances.
+
+Afterwards, run `systemctl daemon-reload && systemctl restart statsdsplitter`

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -22,6 +22,7 @@ The solution is to use an alternative configuration for graphite/statsd, along w
    docker run -d\
     --name graphite\
     --restart=always\
+    --privileged\
     -p 8080:80\
     -p 8225:8125/udp\
     -p 8126:8126\

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -10,7 +10,7 @@ The solution is to use an alternative configuration for graphite/statsd, along w
    [monitor]
    statsd_address = "udp4://127.0.0.1:8325"
    ```
-3. Copy [extra/statsdduplicator.service](/extra/statsdduplicator.service) from this repo to /usr/lib/systemd/system/statsdsplitter.service on your ground station machine
+3. Copy [extra/statsdduplicator.service](/extra/statsdduplicator.service) from this repo to /usr/lib/systemd/system/statsdduplicator.service on your ground station machine
 4. Run the following commands **as root**:
     ```
     systemctl daemon-reload

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -10,7 +10,7 @@ The solution is to use an alternative configuration for graphite/statsd, along w
    [monitor]
    statsd_address = "udp4://127.0.0.1:8325"
    ```
-3. Copy [extra/statsdduplicator.service](/extra/statsdduplicator.service) from this repo to /usr/lib/systemd/system/statsdduplicator.service on your ground station machine
+3. Copy [extra/statsdduplicator.service](/extra/statsdduplicator.service) from this repo to /lib/systemd/system/statsdduplicator.service on your ground station machine
 4. Run the following commands **as root**:
     ```
     systemctl daemon-reload
@@ -42,6 +42,6 @@ Goesrecv sends statsd statistics to the StatsD Duplicator service on port 8325. 
 As root, run `docker stop graphite && docker rm graphite`. Then `docker run...` command above to make it use the custom port.
 
 #### I'm an advanced user, and I have graphite and Grafana running on different machines. How do I make this work for me?
-After creating the file at /usr/lib/systemd/system/statsdsplitter.service on your ground station, edit it (ex. `sudo nano /usr/lib/systemd/system/statsdsplitter.service`). Edit the IPs and ports after each `udp4-datagram` to match your Grafana and graphite/statsd instances.
+After creating the file at /lib/systemd/system/statsdduplicator.service on your ground station, edit it (ex. `sudo nano /lib/systemd/system/statsdduplicator.service`). Edit the IPs and ports after each `udp4-datagram` to match your Grafana and graphite/statsd instances.
 
-Afterwards, run `systemctl daemon-reload && systemctl restart statsdsplitter`
+Afterwards, run `systemctl daemon-reload && systemctl restart statsdduplicator`

--- a/extra/statsdduplicator.service
+++ b/extra/statsdduplicator.service
@@ -1,0 +1,16 @@
+# Receive statsd stats, and send them to 2 services
+
+[Unit]
+Description=StatsD Statistics Duplicator
+Documentation=https://www.github.com/JVital2013/vitality-goes/docs/grafana-compatibility.md
+Wants=network.target
+
+[Service]
+ExecStart=/bin/bash -c 'socat -U - udp4-recv:8325 | tee >(socat -u - udp4-datagram:127.0.0.1:8225) | socat -u - udp4-datagram:127.0.0.1:8125'
+StandardOutput=null
+Type=simple
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This pull contains 2 fixes:

1. **Graphite would not install on some versions of Raspberry Pi OS due to an old version of libseccomp2.** Work around it by using the --privileged flag
2. **It appears goesrecv cannot send statistics to multiple statsd receivers at once.** So, if you have Grafana set up, how can you keep using it? To work around the issue, I'm include a simple "service" that accepts statsd packets from goesrecv. It will then forward the packets to both Graphite and Grafana.

Fixes #9