### PR TITLE
Implement Color Coded Cards

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -77,13 +77,15 @@ To understand how these config files work, let's look at an example section:
 [fdfc_16]
 path = {GOES16}/goes16/fd/fc/
 title = "GOES 16 - Color"
+color = #003241
 videoPath = GOES16FalseColor.mp4
 ```
 
 * `[fdfc_16]`: A unique identifier for the image. This can be anything, but it must be unique and contain no spaces
 * `path`: The folder that holds all the images for a particular GOES product. In this example, it uses the `{GOES16}` variable defined in the `Paths` section of config.ini
 * `title`: How the image will be labeled in Vitality GOES
-* `videoPath`: the name of the video file that contains the timelapse of this product. Videos must be rendered seperately (by the [provided script](scripts.md#createvideos-abish) or any other means), and they must be kept in the `html/videos` folder of Vitality GOES. If you're not rendering timelapse videos, comment or remove this line.
+* `color` *(Optional)*: Color of the image's card in the web interface. Any CSS color code can be used. The color setting is optional and is not configured by default.
+* `videoPath` *(Optional)*: the name of the video file that contains the timelapse of this product. Videos must be rendered seperately (by the [provided script](scripts.md#createvideos-abish) or any other means), and they must be kept in the `html/videos` folder of Vitality GOES. If you're not rendering timelapse videos, comment or remove this line.
 
 ## emwin.ini
 

--- a/html/config/abi.ini
+++ b/html/config/abi.ini
@@ -6,6 +6,7 @@ title = "GOES 16 - Color"
 ;[fdsanchez_16]
 ;path = {GOES16}/goes16/fd/sanchez/
 ;title = "GOES 16 - Sanchez False Color"
+;color = #00391D
 ;videoPath = GOES16Sanchez.mp4
 
 [fdch02_16]
@@ -76,19 +77,23 @@ title = "GOES 16 - Channel 15 (Dirty Longwave IR, Enhanced)"
 [fdgoes17_16]
 path = {GOES16}/goes17/fd/ch13/
 title = "GOES 17 - Channel 13 (Clean Longwave IR Relay)"
+;color = #003241
 ;videoPath = GOES17Ch13.mp4
 
 [fdgoes17e_16]
 path = {GOES16}/goes17/fd/ch13_enhanced/
 title = "GOES 17 - Channel 13 (Relay; Enhanced)"
+;color = #003241
 ;videoPath = GOES17Ch13Enhanced.mp4
 
 ;[fdgoes17Sanchez_16]
 ;path = {GOES16}/goes17/fd/sanchez/
 ;title = "GOES 17 - Sanchez False Color (Relay)"
+;color = #00391D
 ;videoPath = GOES17Sanchez.mp4
 
 ;[composite1617]
 ;path = {GOES16}/composite/
 ;title = "GOES 16/17 Sanchez Composite"
+;color = #00391D
 ;videoPath = Composite.mp4

--- a/html/script.js
+++ b/html/script.js
@@ -54,10 +54,12 @@ function renderMenuItem(index, icon, name)
 	newMenuItem.innerHTML = "<div class='menuItemIconHolder'><i class='fa fa-" + icon + "' aria-hidden='true'></i></div><div style='vertical-align: middle; display: inline-block;'>" + name + "</div>";
 	document.getElementById('sideBar').appendChild(newMenuItem);
 }
-function renderImageCard(slug)
+function renderImageCard(slug, color)
 {
 	card = document.createElement('div');
 	card.className = "prettyBox";
+	if(color != null) card.style.backgroundColor = color;
+	
 	header = document.createElement('div');
 	header.className = "prettyBoxHeader";
 	header.innerHTML = "<i class='fa fa-chevron-" + (expandedCards.includes(slug + "Content") ? "down" : "right") + "' aria-hidden='true'></i>&nbsp;&nbsp;&nbsp;&nbsp;" + config[imageType][slug].title;
@@ -511,25 +513,25 @@ function menuSelect(menuNumber)
 		case 1:
 		barTitle.innerHTML = "Full Disk";
 		mainContent.innerHTML = "";
-		Object.keys(config.abi).forEach(function(key){renderImageCard(key);});
+		Object.keys(config.abi).forEach(function(key){renderImageCard(key, config.abi[key].color);});
 		break;
 		
 		case 2:
 		barTitle.innerHTML = "Level 2 Imagery";
 		mainContent.innerHTML = "";
-		Object.keys(config.l2).forEach(function(key){renderImageCard(key);});
+		Object.keys(config.l2).forEach(function(key){renderImageCard(key, config.abi[key].color);});
 		break;
 		
 		case 3:
 		barTitle.innerHTML = "Mesoscale Imagery";
 		mainContent.innerHTML = "";
-		Object.keys(config.meso).forEach(function(key){renderImageCard(key);});
+		Object.keys(config.meso).forEach(function(key){renderImageCard(key, config.abi[key].color);});
 		break;
 
 		case 4:
 		barTitle.innerHTML = "EMWIN Imagery";
 		mainContent.innerHTML = "";
-		Object.keys(config.emwin).forEach(function(key){renderImageCard(key);});
+		Object.keys(config.emwin).forEach(function(key){renderImageCard(key, config.abi[key].color);});
 		break;
 		
 		case 5:


### PR DESCRIPTION
Allow setting a `color` variable in abi, l2, meso, and emwin.ini files to color the card in the web interface. Example: [https://i.imgur.com/XV3dTNu.png](https://i.imgur.com/XV3dTNu.png)

Implements #14 