### PR TITLE
Add support for SatDump

### DIFF
--- a/extra/config-satdump/abi.ini
+++ b/extra/config-satdump/abi.ini
@@ -1,0 +1,57 @@
+[fdfc_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Color"
+filter = "_FC_"
+;videoPath = GOES16FalseColor.mp4
+
+[fdch02_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 2 (Red)"
+filter = "_2_"
+;videoPath = GOES16Ch2.mp4
+
+[fdch07_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 7 (Shortwave IR)"
+filter = "_7_"
+;videoPath = GOES16Ch7.mp4
+
+[fdch08_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 8 (Upper Troposphere)"
+filter = "_8_"
+;videoPath = GOES16Ch8.mp4
+
+[fdch09_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 9 (Mid Troposphere)"
+filter = "_9_"
+;videoPath = GOES16Ch9.mp4
+
+[fdch13_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 13 (Clean Longwave IR)"
+filter = "_13_"
+;videoPath = GOES16Ch13.mp4
+
+[fdch14_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 14 (Longwave IR)"
+filter = "_14_"
+;videoPath = GOES16Ch14.mp4
+
+[fdch15_16]
+path = "{GOES16}\IMAGES\GOES-16\Full Disk"
+title = "GOES 16 - Channel 15 (Dirty Longwave IR)"
+filter = "_15_"
+;videoPath = GOES16Ch15.mp4
+
+[fd_17]
+path = "{GOES16}\IMAGES\GOES-17\Full Disk"
+title = "GOES 17 - Channel 13 (Relay)"
+filter = "_13_"
+
+[fd_18]
+path = "{GOES16}\IMAGES\GOES-18\Full Disk"
+title = "GOES 18 - Channel 13 (Relay)"
+filter = "_13_"

--- a/extra/config-satdump/config.ini
+++ b/extra/config-satdump/config.ini
@@ -1,0 +1,18 @@
+[general]
+emwinPath = "F:\Progs\SatDump-1.0.1\live_output\2022-11-19_02-15_goes_hrit_1694Mhz\EMWIN"
+showSysInfo = false
+debug = false
+
+[paths]
+GOES16 = "F:\Progs\SatDump-1.0.1\live_output\2022-11-19_02-15_goes_hrit_1694Mhz"
+
+[location]
+radarCode = NTHES
+stateAbbr = MD
+wxZone = MDZ013
+orig = LWXMD
+;rwrOrig = LWXMD
+city = COLLEGE PARK
+lat = 39.02
+lon = -76.98
+timezone = America/New_York

--- a/extra/config-satdump/meso.ini
+++ b/extra/config-satdump/meso.ini
@@ -1,4 +1,4 @@
-[m2fc_16]
+[m1fc_16]
 path = "{GOES16}\IMAGES\GOES-16\Mesoscale 1"
 title = "GOES 16 - M1 - False Color"
 filter = "_FC_"

--- a/extra/config-satdump/meso.ini
+++ b/extra/config-satdump/meso.ini
@@ -1,0 +1,47 @@
+[m2fc_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 1"
+title = "GOES 16 - M1 - False Color"
+filter = "_FC_"
+;videoPath = GOES16FalseColor_M1.mp4
+
+[m1ch02_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 1"
+title = "GOES 16 - M1 - Channel 2 (Red)"
+filter = "_2_"
+;videoPath = GOES16Ch2_M1.mp4
+
+[m1ch07_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 1"
+title = "GOES 16 - M1 - Channel 7 (Shortwave IR)"
+filter = "_7_"
+;videoPath = GOES16Ch7_M1.mp4
+
+[m1ch13_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 1"
+title = "GOES 16 - M1 - Channel 13 (Clean Longwave IR)"
+filter = "_13_"
+;videoPath = GOES16Ch13_M1.mp4
+
+[m2fc_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 2"
+title = "GOES 16 - M2 - False Color"
+filter = "_FC_"
+;videoPath = GOES16FalseColor_M2.mp4
+
+[m2ch02_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 2"
+title = "GOES 16 - M2 - Channel 2 (Red)"
+filter = "_2_"
+;videoPath = GOES16Ch2_M2.mp4
+
+[m2ch07_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 2"
+title = "GOES 16 - M2 - Channel 7 (Shortwave IR)"
+filter = "_7_"
+;videoPath = GOES16Ch7_M2.mp4
+
+[m2ch13_16]
+path = "{GOES16}\IMAGES\GOES-16\Mesoscale 2"
+title = "GOES 16 - M2 - Channel 13 (Clean Longwave IR)"
+filter = "_13_"
+;videoPath = GOES16Ch13_M2.mp4

--- a/html/dataHandler.php
+++ b/html/dataHandler.php
@@ -19,7 +19,7 @@
 
 //Load External Functions
 require_once($_SERVER['DOCUMENT_ROOT'] . "/functions.php");
-$config = loadConfig(); //TODO: Handle errors here
+$config = loadConfig();
 
 //Only display errors if set to in the config
 ini_set("display_errors", ($config['general']['debug'] ? "On" : "Off"));
@@ -177,19 +177,19 @@ elseif($_GET['type'] == "abiMetadata")
 {
 	if(!array_key_exists($_GET['id'], $config['abi'])) die();
 	header('Content-Type: application/json; charset=utf-8');
-	echo json_encode(findMetadataABI($config['abi'][$_GET['id']]['path'], $config['abi'][$_GET['id']]['title']));
+	echo json_encode(findMetadataABI($config['abi'][$_GET['id']]['path'], $config['abi'][$_GET['id']]['filter'], $config['abi'][$_GET['id']]['title']));
 }
 elseif($_GET['type'] == "l2Metadata")
 {
 	if(!array_key_exists($_GET['id'], $config['l2'])) die();
 	header('Content-Type: application/json; charset=utf-8');
-	echo json_encode(findMetadataABI($config['l2'][$_GET['id']]['path'], $config['l2'][$_GET['id']]['title']));
+	echo json_encode(findMetadataABI($config['l2'][$_GET['id']]['path'], $config['l2'][$_GET['id']]['filter'], $config['l2'][$_GET['id']]['title']));
 }
 elseif($_GET['type'] == "mesoMetadata")
 {
 	if(!array_key_exists($_GET['id'], $config['meso'])) die();
 	header('Content-Type: application/json; charset=utf-8');
-	echo json_encode(findMetadataABI($config['meso'][$_GET['id']]['path'], $config['meso'][$_GET['id']]['title']));
+	echo json_encode(findMetadataABI($config['meso'][$_GET['id']]['path'], $config['meso'][$_GET['id']]['filter'], $config['meso'][$_GET['id']]['title']));
 }
 elseif($_GET['type'] == "emwinMetadata")
 {
@@ -471,7 +471,7 @@ elseif($_GET['type'] == "metadata")
 elseif($_GET['type'] == "abiData")
 {
 	if(!array_key_exists($_GET['id'], $config['abi']) || !array_key_exists('timestamp', $_GET)) die();
-	$path = findImageABI($config['abi'][$_GET['id']]['path'], $_GET['timestamp']);
+	$path = findImageABI($config['abi'][$_GET['id']]['path'], $config['abi'][$_GET['id']]['filter'], $_GET['timestamp']);
 	header('Content-Type: ' . mime_content_type($path));
 	header('Content-Disposition: inline; filename=' . basename($path));
 	header('Content-Length: ' . filesize($path));
@@ -480,7 +480,7 @@ elseif($_GET['type'] == "abiData")
 elseif($_GET['type'] == "l2Data")
 {
 	if(!array_key_exists($_GET['id'], $config['l2']) || !array_key_exists('timestamp', $_GET)) die();
-	$path = findImageABI($config['l2'][$_GET['id']]['path'], $_GET['timestamp']);
+	$path = findImageABI($config['l2'][$_GET['id']]['path'], $config['l2'][$_GET['id']]['filter'], $_GET['timestamp']);
 	header('Content-Type: ' . mime_content_type($path));
 	header('Content-Disposition: inline; filename=' . basename($path));
 	header('Content-Length: ' . filesize($path));
@@ -489,7 +489,7 @@ elseif($_GET['type'] == "l2Data")
 elseif($_GET['type'] == "mesoData")
 {
 	if(!array_key_exists($_GET['id'], $config['meso']) || !array_key_exists('timestamp', $_GET)) die();
-	$path = findImageABI($config['meso'][$_GET['id']]['path'], $_GET['timestamp']);
+	$path = findImageABI($config['meso'][$_GET['id']]['path'], $config['meso'][$_GET['id']]['filter'], $_GET['timestamp']);
 	header('Content-Type: ' . mime_content_type($path));
 	header('Content-Disposition: inline; filename=' . basename($path));
 	header('Content-Length: ' . filesize($path));

--- a/html/functions.php
+++ b/html/functions.php
@@ -18,21 +18,41 @@
  */
 function loadConfig()
 {
-	//TODO: Check if the file exists. If config.ini is missing, throw error. Otherwise, return empty array
+	//Load main config
 	$config = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/config.ini", true, INI_SCANNER_RAW);
 	$config['general']['showSysInfo'] = (stripos($config['general']['showSysInfo'], "true") !== false);
 	$config['general']['debug'] = (stripos($config['general']['debug'], "true") !== false);
-	$config['abi'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/abi.ini", true, INI_SCANNER_RAW);
-	$config['meso'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/meso.ini", true, INI_SCANNER_RAW);
-	$config['l2'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/l2.ini", true, INI_SCANNER_RAW);
-	$config['emwin'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/emwin.ini", true, INI_SCANNER_RAW);
 	
-	//Parse ABI Configs
-	parseABIConfig($config, $config['abi']);
-	parseABIConfig($config, $config['meso']);
-	parseABIConfig($config, $config['l2']);
+	//Load extra configs, allow them to not exist
+	if(file_exists($_SERVER['DOCUMENT_ROOT'] . "/config/abi.ini"))
+	{
+		$config['abi'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/abi.ini", true, INI_SCANNER_RAW);
+		parseABIConfig($config, $config['abi']);
+	}
+	else $config['abi'] = [];
+	
+	if(file_exists($_SERVER['DOCUMENT_ROOT'] . "/config/meso.ini"))
+	{
+		$config['meso'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/meso.ini", true, INI_SCANNER_RAW);
+		parseABIConfig($config, $config['meso']);
+	}
+	else $config['meso'] = [];
+	
+	if(file_exists($_SERVER['DOCUMENT_ROOT'] . "/config/l2.ini"))
+	{
+		$config['l2'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/l2.ini", true, INI_SCANNER_RAW);
+		parseABIConfig($config, $config['l2']);
+	}
+	else $config['l2'] = [];
+	
+	if(file_exists($_SERVER['DOCUMENT_ROOT'] . "/config/emwin.ini"))
+	{
+		$config['emwin'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/emwin.ini", true, INI_SCANNER_RAW);
+	}
+	else $config['emwin'] = [];
+	
+	//Config touchups
 	if(array_key_exists('paths', $config)) unset($config['paths']);
-	
 	if(!array_key_exists('city', $config['location'])) $config['location']['city'] = "";
 	if(!array_key_exists('rwrOrig', $config['location'])) $config['location']['rwrOrig'] = $config['location']['orig'];
 	if(!array_key_exists('emwinPath', $config['general'])) $config['emwin'] = [];

--- a/html/functions.php
+++ b/html/functions.php
@@ -18,6 +18,7 @@
  */
 function loadConfig()
 {
+	//TODO: Check if the file exists. If config.ini is missing, throw error. Otherwise, return empty array
 	$config = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/config.ini", true, INI_SCANNER_RAW);
 	$config['general']['showSysInfo'] = (stripos($config['general']['showSysInfo'], "true") !== false);
 	$config['general']['debug'] = (stripos($config['general']['debug'], "true") !== false);
@@ -25,27 +26,29 @@ function loadConfig()
 	$config['meso'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/meso.ini", true, INI_SCANNER_RAW);
 	$config['l2'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/l2.ini", true, INI_SCANNER_RAW);
 	$config['emwin'] = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/config/emwin.ini", true, INI_SCANNER_RAW);
-	$abiSlugs = array_keys($config['abi']);
-	$mesoSlugs = array_keys($config['meso']);
-	$l2Slugs = array_keys($config['l2']);
-	$emwinSlugs = array_keys($config['emwin']);
 	
-	if(array_key_exists('paths', $config))
-	{
-		foreach($config['paths'] as $key => $value)
-		{
-			for($i = 0; $i < count($config['abi']); $i++) $config['abi'][$abiSlugs[$i]]['path'] = str_replace('{' . $key . '}', $value, $config['abi'][$abiSlugs[$i]]['path']);
-			for($i = 0; $i < count($config['meso']); $i++) $config['meso'][$mesoSlugs[$i]]['path'] = str_replace('{' . $key . '}', $value, $config['meso'][$mesoSlugs[$i]]['path']);
-			for($i = 0; $i < count($config['l2']); $i++) $config['l2'][$l2Slugs[$i]]['path'] = str_replace('{' . $key . '}', $value, $config['l2'][$l2Slugs[$i]]['path']);
-		}
-		unset($config['paths']);
-	}
+	//Parse ABI Configs
+	parseABIConfig($config, $config['abi']);
+	parseABIConfig($config, $config['meso']);
+	parseABIConfig($config, $config['l2']);
+	if(array_key_exists('paths', $config)) unset($config['paths']);
 	
 	if(!array_key_exists('city', $config['location'])) $config['location']['city'] = "";
 	if(!array_key_exists('rwrOrig', $config['location'])) $config['location']['rwrOrig'] = $config['location']['orig'];
 	if(!array_key_exists('emwinPath', $config['general'])) $config['emwin'] = [];
 	
 	return $config;
+}
+
+function parseABIConfig($config, &$abiConfig)
+{
+	$slugs = array_keys($abiConfig);
+	for($i = 0; $i < count($abiConfig); $i++)
+	{
+		if(!array_key_exists("filter", $abiConfig[$slugs[$i]])) $abiConfig[$slugs[$i]]['filter'] = "";
+		if(array_key_exists('paths', $config)) foreach($config['paths'] as $key => $value)
+			$abiConfig[$slugs[$i]]['path'] = str_replace('{' . $key . '}', $value, $abiConfig[$slugs[$i]]['path']);
+	}
 }
 
 function scandir_recursive($dir, &$results = array())
@@ -157,13 +160,13 @@ function findMetadataEMWIN($allEmwinFiles, $product, $title)
 	return $retVal;
 }
 
-function findMetadataABI($path, $title)
+function findMetadataABI($path, $filter, $title)
 {
 	if(!is_dir($path)) return array();
 	
 	$retVal = [];
 	$fileList = scandir_recursive($path);
-	$fileList = preg_grep("/_[0-9]{8}T[0-9]{6}Z\..{3}$/", $fileList);
+	$fileList = preg_grep("/(\\\\|\/)[^\\\\\/]*${filter}[^\\\\\/]*[0-9]{8}T[0-9]{6}Z\..{3}$/", $fileList);
 	usort($fileList, "sortABI");
 	
 	foreach($fileList as $file)
@@ -181,13 +184,13 @@ function findMetadataABI($path, $title)
 	return $retVal;
 }
 
-function findImageABI($path, $timestamp)
+function findImageABI($path, $filter, $timestamp)
 {
 	$DateTime = new DateTime("now", new DateTimeZone("UTC"));
 	$DateTime->setTimestamp($timestamp);
 	
 	$fileList = scandir_recursive($path);
-	foreach($fileList as $thisFile) if(strpos($thisFile, $DateTime->format('Ymd\THis\Z'))) return $thisFile;
+	foreach($fileList as $thisFile) if(preg_match("/(\\\\|\/)[^\\\\\/]*${filter}[^\\\\\/]*" . $DateTime->format('Ymd\THis\Z') . "\..{3}$/", $thisFile)) return $thisFile;
 }
 
 function linesToParagraphs($lineArray, $linesToSkip)


### PR DESCRIPTION
SatDump does not separate images by channel - they're all in the same "Full Disk", "Mesoscale 1", etc directory. This PR allows Vitality GOES users to add a "filter" key to each image defined in abi.ini, meso.ini, and l2.ini - and therefore, make it compatible with a SatDump data source.

The filter key should match a short string that exists in the filename of a specific channel. For example, SatDump put _2_ in the filename of Channel 2 images from the GOES satellites, so set `filter = "_2_"`  in abi.ini to properly select these images. _Example configs for using Vitality GOES can be found under /extra/config-satdump of this branch._

**Note:** This PR will not be merged until https://github.com/altillimity/SatDump/issues/170 is implemented. This PR will make Vitality GOES work with SatDump as-is, but I want to give the best guidance in my documentation for future SatDump compatibility. Depending on how SatDump implements the suggestion, this branch may never be merged into Vitality GOES